### PR TITLE
Toggle FAQ accordion icon dynamically

### DIFF
--- a/conversationally/frontend/src/pages/landingPage/sections/FAQs.jsx
+++ b/conversationally/frontend/src/pages/landingPage/sections/FAQs.jsx
@@ -4,6 +4,7 @@ import AccordionSummary from '@mui/material/AccordionSummary';
 import AccordionDetails from '@mui/material/AccordionDetails';
 import Typography from '@mui/material/Typography';
 import AddIcon from '@mui/icons-material/Add';
+import RemoveIcon from '@mui/icons-material/Remove';
 import { Card } from '@mui/material';
 
 const FAQs = (props) => {
@@ -33,6 +34,11 @@ const FAQs = (props) => {
     },
   };
 
+  const [expanded, setExpanded] = React.useState(null);
+
+  const toggleAccordion = (panel) => (event, isExpanded) => {
+    setExpanded(isExpanded ? panel : null);
+  };
 
   return (
     <div style={{ display: 'flex', justifyContent: 'center' }}>
@@ -45,9 +51,15 @@ const FAQs = (props) => {
 
         <div style={styles.accordionContainer}>
           {props.faqs.map((faq, index) => (
-            <Accordion key={index}>
+            <Accordion
+              key={index}
+              expanded={expanded === `panel${index}`}
+              onChange={toggleAccordion(`panel${index}`)}
+            >
               <AccordionSummary
-                expandIcon={<AddIcon />}
+                expandIcon={
+                  expanded === `panel${index}` ? <RemoveIcon /> : <AddIcon />
+                }
                 aria-controls={`panel${index}a-content`}
                 id={`panel${index}a-header`}
               >


### PR DESCRIPTION
Updated the code to dynamically switch between the Add and Remove icons in the AccordionSummary component, depending on whether a section is expanded or collapsed. Introduced the toggleAccordion function to manage the expanded state for improved user interaction.

Fixes #95

### Collapsed
<img width="648" alt="Screenshot 2023-12-18 at 14 10 38" src="https://github.com/life-efficient/Conversationally/assets/781693/1ef49b20-0e3c-4327-bcc8-e6d8b4f03c2b">

### Expanded
<img width="644" alt="Screenshot 2023-12-18 at 14 09 17" src="https://github.com/life-efficient/Conversationally/assets/781693/2ef4b0df-ae2d-41be-9ced-b181b98d589a">

